### PR TITLE
chore: bump critical-section to 1.2.0, since older versions were yanked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bumped `critical-section` to 1.2.0, since the previous version was yanked
+- Fixed soundness issue caught by new version of miri
+
 ## [0.1.0] - 2022-04-20
 
 - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ include = [
 
 [dependencies]
 critical-section = "1.2.0"
+
+[dev-dependencies]
+critical-section = { version = "1.2.0", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-critical-section = "0.2.7"
+critical-section = "1.2.0"


### PR DESCRIPTION
Please merge and release new version.

Older versions of critical-section were yanked.

Thanks :-)